### PR TITLE
Add support for quicklist data type

### DIFF
--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -472,6 +472,8 @@ class RdbParser :
             skip_strings = 1
         elif enc_type == REDIS_RDB_TYPE_HASH_ZIPLIST :
             skip_strings = 1
+        elif enc_type == REDIS_RDB_TYPE_LIST_QUICKLIST :
+            skip_strings = self.read_length(f)
         else :
             raise Exception('read_object', 'Invalid object type %d for key %s' % (enc_type, self._key))
         for x in xrange(0, skip_strings):


### PR DESCRIPTION
Fixes a bug where exception is raised when generating memory report for particular data types:

```
$ rdb -c memory --type hash /var/redis/6379/dump.rdb > memory_hashes.csv

Exception: ('read_object', 'Invalid object type 14 for key ...')
```

This fix enables support for Quicklist data type so that the `skip_object` method can skip the right number of bytes, instead of raising `Exception('read_object')`

---

P/S: @mihu, since your repo is the most compatible with latest version of Redis, it might be useful to update the README, to make it convenient for others to install from your repo.

```
# under 'Installing rdbtools'

git clone https://github.com/mihu/redis-rdb-tools
cd redis-rdb-tools
sudo python setup.py install
```

Thanks for making this tool compatible for Redis 3.2! 😄 