### PR TITLE
Read rdb directly from fd stream and handle checksum bytes at the end 

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -247,12 +247,11 @@ class DiffCallback(RdbCallback):
         pass
     
     def start_sorted_set(self, key, length, expiry, info):
-        self._index = 0
-    
+        pass
+
     def zadd(self, key, score, member):
-        self._out.write('db=%d %s[%d] -> {%s, score=%s}' % (self._dbnum, encode_key(key), self._index, encode_key(member), encode_value(score)))
+        self._out.write('db=%d %s -> {%s, score=%s}' % (self._dbnum, encode_key(key), encode_key(member), encode_value(score)))
         self.newline()
-        self._index = self._index + 1
     
     def end_sorted_set(self, key):
         pass

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -306,8 +306,8 @@ class RdbParser :
                 if data_type == REDIS_RDB_OPCODE_EOF :
                     self._callback.end_database(db_number)
                     self._callback.end_rdb()
-                        if self._rdb_version >= 5:
-                            f.read(8)
+                    if self._rdb_version >= 5:
+                        f.read(8)
                     break
 
                 if self.matches_filter(db_number) :

--- a/rdbtools/parser.py
+++ b/rdbtools/parser.py
@@ -468,7 +468,7 @@ class RdbParser :
         elif enc_type == REDIS_RDB_TYPE_HASH_ZIPLIST :
             skip_strings = 1
         else :
-            raise Exception('read_object', 'Invalid object type %d for key %s' % (enc_type, self._key))
+            raise Exception('skip_object', 'Invalid object type %d for key %s' % (enc_type, self._key))
         for x in xrange(0, skip_strings):
             self.skip_string(f)
 


### PR DESCRIPTION
Read rdb directly from fd stream and handle checksum bytes at the end (if required by the rdb version). This enables receiving the rdb file from a stream (socket for example) and parsing it on the fly.

Also added to this PR:

*   A fix to the diff callback to make zset diff's practical.
*  Bugfix parsing nan/inf score values in skiplist zsets.

