### PR TITLE
Fix issue #22.

### DIFF
--- a/rdbtools/callbacks.py
+++ b/rdbtools/callbacks.py
@@ -134,7 +134,7 @@ class JSONCallback(RdbCallback):
         pass
     
     def _write_comma(self):
-        if self._element_index > 0 and self._element_index < self._elements_in_key :
+        if self._element_index > 0 :
             self._out.write(',')
         self._element_index = self._element_index + 1
         


### PR DESCRIPTION
Include commas between key:value pairs for hashes longer than 253. Remove redundant check in _write_comma function which resulted in missing commas when the length of a hash is 254 or more.

run_tests returns OK.