### PR TITLE
MShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Rdbtools is a parser for Redis' dump.rdb files. The parser generates events simi
 In addition, rdbtools provides utilities to :
 
  1.  Generate a Memory Report of your data across all databases and keys
- 2.  Convert dump files to JSON
- 3.  Compare two dump files using standard diff tools
+ 2.  Analyze memory used across keys using an interactive Memory Shell
+ 3.  Convert dump files to JSON
+ 4.  Compare two dump files using standard diff tools
 
 Rdbtools is written in Python, though there are similar projects in other languages. See [FAQs](https://github.com/sripathikrishnan/redis-rdb-tools/wiki/FAQs) for more information.
 
@@ -83,6 +84,40 @@ NOTE :
 
 1. This was added to redis-rdb-tools version 0.1.3
 2. This command depends [redis-py](https://github.com/andymccurdy/redis-py) package
+
+## Open an interactive Memory Shell ##
+
+Sometimes you want to do a quick memory analysis across a few keys or even entire key namespaces, but summing up dump report values can be time consuming.
+
+For these cases, RDB tools offers an interactive Memory Shell dubbed "MShell", which loads the approximate memory sizes of all keys into memory for quick querying.
+
+*Beware, this can take a minute to prepare and be memory-consuming for large-scale dump files since it's all stored in memory.*
+
+Start MShell :
+
+    rdb -c mshell dump.rdb
+    
+    Welcome to RDB MShell!
+    mshell> 
+
+Get approximate memory usage for a specific key, `user:123:items` :
+
+    mshell> info user:123:items
+    25136234 bytes (2.829%)
+
+Get a wildcard range across a specific namespace, all keys starting with `user:*` :
+
+    mshell> info user:*
+    710816090 bytes (80.000%)
+
+See approximate memory usage of all keys :
+
+    mshell> info *
+    888520112 bytes (100.000%)
+
+
+MShell also offers auto-complete support, which is helpful for when you don't remember exact key or namespace values.
+
 
 ## Comparing RDB files ##
 
@@ -171,4 +206,5 @@ Sripathi Krishnan : @srithedabbler
  5. [Josep M. Pujol](https://github.com/solso)
  6. [Charles Gordon](https://github.com/cgordon)
  7. [Justin Poliey](https://github.com/jdp)
+ 7. [Loisaida Sam Sandberg](https://github.com/loisaidasam)
 

--- a/rdbtools/__init__.py
+++ b/rdbtools/__init__.py
@@ -1,10 +1,10 @@
 from rdbtools.parser import RdbCallback, RdbParser, DebugCallback
 from rdbtools.callbacks import JSONCallback, DiffCallback, ProtocolCallback
-from rdbtools.memprofiler import MemoryCallback, PrintAllKeys, StatsAggregator
+from rdbtools.memprofiler import MemoryCallback, PrintAllKeys, StoreAllKeysInMemory, StatsAggregator, MShell
 
 __version__ = '0.1.6'
 VERSION = tuple(map(int, __version__.split('.')))
 
 __all__ = [
-    'RdbParser', 'RdbCallback', 'JSONCallback', 'DiffCallback', 'MemoryCallback', 'ProtocolCallback', 'PrintAllKeys']
+    'RdbParser', 'RdbCallback', 'JSONCallback', 'DiffCallback', 'MemoryCallback', 'ProtocolCallback', 'PrintAllKeys', 'StoreAllKeysInMemory', 'MShell']
 

--- a/rdbtools/cli/rdb.py
+++ b/rdbtools/cli/rdb.py
@@ -2,7 +2,7 @@
 import os
 import sys
 from optparse import OptionParser
-from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, ProtocolCallback, PrintAllKeys
+from rdbtools import RdbParser, JSONCallback, DiffCallback, MemoryCallback, ProtocolCallback, PrintAllKeys, StoreAllKeysInMemory, MShell
 
 VALID_TYPES = ("hash", "set", "string", "list", "sortedset")
 def main():
@@ -12,7 +12,7 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
 
     parser = OptionParser(usage=usage)
     parser.add_option("-c", "--command", dest="command",
-                  help="Command to execute. Valid commands are json, diff, and protocol", metavar="FILE")
+                  help="Command to execute. Valid commands are json, diff, protocol, and mshell", metavar="FILE")
     parser.add_option("-f", "--file", dest="output",
                   help="Output file", metavar="FILE")
     parser.add_option("-n", "--db", dest="dbs", action="append",
@@ -75,12 +75,18 @@ Example : %prog --command json -k "user.*" /var/redis/6379/dump.rdb"""
             callback = MemoryCallback(reporter, 64)
         elif 'protocol' == options.command:
             callback = ProtocolCallback(sys.stdout)
+        elif 'mshell' == options.command:
+            reporter = StoreAllKeysInMemory()
+            callback = MemoryCallback(reporter, 64)
         else:
             raise Exception('Invalid Command %s' % options.command)
 
         parser = RdbParser(callback, filters=filters)
         parser.parse(dump_file)
-    
+
+        if 'mshell' == options.command:
+            MShell(reporter).cmdloop()
+
 if __name__ == '__main__':
     main()
 

--- a/rdbtools/memprofiler.py
+++ b/rdbtools/memprofiler.py
@@ -417,7 +417,6 @@ class MShell(cmd.Cmd):
                     # If there is a colon, only add part up to the colon
                     key_result = key_result[:pos_of_colon] + ':'
             results.add(key_result)
-        # logger.info("results: %s", sorted(results))
         return sorted(results)
 
     def do_EOF(self, line):


### PR DESCRIPTION
Sometimes you want to do a quick memory analysis across a few keys or even entire key namespaces, but summing up dump report values can be time consuming.

For these cases, I present an interactive Memory Shell dubbed "MShell", which loads the approximate memory sizes of all keys into memory for quick querying.

Comes complete with support for wildcard matching and auto-complete.
